### PR TITLE
Add default handle_info for child exit

### DIFF
--- a/lib/highlander.ex
+++ b/lib/highlander.ex
@@ -96,6 +96,10 @@ defmodule Highlander do
     {:stop, {:shutdown, :name_conflict}, Map.delete(state, :pid)}
   end
 
+  def handle_info({:EXIT, pid, reason}, %{pid: pid} = state) do
+    {:stop, reason, Map.delete(state, :pid)}
+  end
+
   @impl true
   def terminate(reason, %{pid: pid}) do
     :ok = Supervisor.stop(pid, reason)


### PR DESCRIPTION
Add `handle_info({:EXIT, pid, reason}, state)` to handle exit messages from child with various reasons (ex. `:shutdown` in case child process is also registered in another global registry and there was a conflict after network split leading to a stop of one of processes). I think it also is better to forward exit reason down the supervisor line, as reasons like `:normal`, `:shutdown` and `{:shutdown, term()}` are ordinary and should not cause logging of error or crash.

We encountered this error during deployments (new nodes are joining running cluster that already has older nodes running, so there seems to be a chance of conflict when new node has already started its child):

```
[error] GenServer #PID<0.6910.0> terminating
** (stop) exited in: GenServer.stop(#PID<0.6911.0>, {:function_clause, [{Highlander, :handle_info, [{:EXIT, #PID<0.6911.0>, :shutdown}, %{child_spec: %{id: Choosy.Some.Process, start: {Choosy.Some.Process, :start_link, [[]]}}, pid: #PID<0.6911.0>}], [file: 'lib/highlander.ex', line: 90]}, {:gen_server, :try_dispatch, 4, [file: 'gen_server.erl', line: 695]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 771]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 226]}]}, :infinity)
** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
(elixir 1.13.4) lib/gen_server.ex:987: GenServer.stop/3
(highlander 0.2.1) lib/highlander.ex:101: Highlander.terminate/2
(stdlib 3.17.2) gen_server.erl:733: :gen_server.try_terminate/3
(stdlib 3.17.2) gen_server.erl:918: :gen_server.terminate/10
(stdlib 3.17.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {:EXIT, #PID<0.6911.0>, :shutdown}

[notice] global: Name conflict terminating {Choosy.Some.Process, #PID<59237.6053.0>}
```